### PR TITLE
adds enhanced single node wandb nb

### DIFF
--- a/train-pytorch-singlenode.ipynb
+++ b/train-pytorch-singlenode.ipynb
@@ -13,8 +13,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
+   "execution_count": 1,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-21T20:38:48.311344Z",
+     "iopub.status.busy": "2021-04-21T20:38:48.311073Z",
+     "iopub.status.idle": "2021-04-21T20:38:48.973682Z",
+     "shell.execute_reply": "2021-04-21T20:38:48.973132Z",
+     "shell.execute_reply.started": "2021-04-21T20:38:48.311275Z"
+    }
+   },
    "outputs": [],
    "source": [
     "import numpy as np\n",
@@ -28,7 +36,8 @@
     "from torch.utils.data import DataLoader\n",
     "from torch.utils.data.sampler import SubsetRandomSampler, RandomSampler\n",
     "from dask_pytorch_ddp import data\n",
-    "import multiprocessing as mp"
+    "import multiprocessing as mp\n",
+    "from fastprogress.fastprogress import master_bar, progress_bar"
    ]
   },
   {
@@ -44,9 +53,35 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 2,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-21T20:38:50.730206Z",
+     "iopub.status.busy": "2021-04-21T20:38:50.729982Z",
+     "iopub.status.idle": "2021-04-21T20:38:51.946721Z",
+     "shell.execute_reply": "2021-04-21T20:38:51.946052Z",
+     "shell.execute_reply.started": "2021-04-21T20:38:50.730183Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[34m\u001b[1mwandb\u001b[0m: Currently logged in as: \u001b[33mmorg\u001b[0m (use `wandb login --relogin` to force relogin)\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "import wandb\n",
     "wandb.login()"
@@ -56,52 +91,22 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Set Model Specifications\n",
-    "\n",
-    "Here you can assign your model hyperparameters, as well as identifying where the training data is housed on S3. All these parameters, as well as some extra elements like Notes and Tags, are tracked by Weights and Biases for you."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "model_params = {'n_epochs': 6, \n",
-    "    'batch_size': 100,\n",
-    "    'base_lr': .01,\n",
-    "    'downsample_to':.5, # Value represents percent of training data you want to use\n",
-    "    'bucket': \"saturn-public-data\",\n",
-    "    'prefix': \"dogs/Images\",\n",
-    "    'pretrained_classes':imagenetclasses} "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "wbargs = {**model_params,\n",
-    "    'classes':120,\n",
-    "    'Notes':\"baseline\",\n",
-    "    'Tags': ['single', 'gpu'],\n",
-    "    'dataset':\"StanfordDogs\",\n",
-    "    'architecture':\"ResNet\"}"
-   ]
-  },
-  {
-   "source": [
     "### Label Formatting \n",
     "These utilities ensure the training data labels correspond to the pretrained model's label expectations."
-   ],
-   "cell_type": "markdown",
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
+   "execution_count": 3,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-21T20:38:55.595630Z",
+     "iopub.status.busy": "2021-04-21T20:38:55.595397Z",
+     "iopub.status.idle": "2021-04-21T20:38:56.181954Z",
+     "shell.execute_reply": "2021-04-21T20:38:56.181379Z",
+     "shell.execute_reply.started": "2021-04-21T20:38:55.595605Z"
+    }
+   },
    "outputs": [],
    "source": [
     "import re\n",
@@ -130,6 +135,60 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## Set Model Specifications\n",
+    "\n",
+    "Here you can assign your model hyperparameters, as well as identifying where the training data is housed on S3. All these parameters, as well as some extra elements like Notes and Tags, are tracked by Weights and Biases for you."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-21T20:38:57.167870Z",
+     "iopub.status.busy": "2021-04-21T20:38:57.167647Z",
+     "iopub.status.idle": "2021-04-21T20:38:57.171190Z",
+     "shell.execute_reply": "2021-04-21T20:38:57.170476Z",
+     "shell.execute_reply.started": "2021-04-21T20:38:57.167848Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "model_params = {'n_epochs': 6, \n",
+    "    'batch_size': 64,\n",
+    "    'base_lr': .01,\n",
+    "    'downsample_to':.5, # Value represents percent of training data you want to use\n",
+    "    'bucket': \"saturn-public-data\",\n",
+    "    'prefix': \"dogs/Images\",\n",
+    "    'pretrained_classes':imagenetclasses} "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-21T20:38:57.915852Z",
+     "iopub.status.busy": "2021-04-21T20:38:57.915615Z",
+     "iopub.status.idle": "2021-04-21T20:38:57.919062Z",
+     "shell.execute_reply": "2021-04-21T20:38:57.918353Z",
+     "shell.execute_reply.started": "2021-04-21T20:38:57.915828Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "wbargs = {**model_params,\n",
+    "    'classes':120,\n",
+    "    'Notes':\"baseline\",\n",
+    "    'Tags': ['single', 'gpu'],\n",
+    "    'dataset':\"StanfordDogs\",\n",
+    "    'architecture':\"ResNet\"}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Training Function\n",
     "\n",
     "This function encompasses the training task. \n",
@@ -142,11 +201,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
+   "execution_count": 6,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-21T20:38:58.957901Z",
+     "iopub.status.busy": "2021-04-21T20:38:58.957679Z",
+     "iopub.status.idle": "2021-04-21T20:38:58.970167Z",
+     "shell.execute_reply": "2021-04-21T20:38:58.969489Z",
+     "shell.execute_reply.started": "2021-04-21T20:38:58.957879Z"
+    }
+   },
    "outputs": [],
    "source": [
-    "def simple_train_single(bucket, prefix,batch_size, downsample_to, n_epochs, base_lr, pretrained_classes): \n",
+    "def simple_train_single(bucket, prefix, batch_size, downsample_to, n_epochs, base_lr, pretrained_classes): \n",
     "    \n",
     "    # --------- Format params --------- #\n",
     "    device = torch.device(\"cuda\")\n",
@@ -191,12 +258,22 @@
     "        num_workers=40, \n",
     "        multiprocessing_context=mp.get_context('fork'))   \n",
     "\n",
+    "    # Using the OneCycleLR learning rate schedule\n",
+    "    scheduler = optim.lr_scheduler.OneCycleLR(optimizer, max_lr=base_lr, \n",
+    "                                                steps_per_epoch=len(train_loader), \n",
+    "                                                epochs=n_epochs)\n",
+    "    \n",
+    "    # ------ Prepare wandb Table for predictions ------- #\n",
+    "    columns=[\"image\", \"label\", \"prediction\", \"score\"]\n",
+    "    preds_table = wandb.Table(columns=columns)\n",
+    "    \n",
     "    # --------- Start Training ------- #\n",
-    "    for epoch in range(n_epochs):\n",
+    "    mb = master_bar(range(n_epochs))\n",
+    "    for epoch in mb:\n",
     "        count = 0\n",
     "        model.train()\n",
     "        \n",
-    "        for inputs, labels in train_loader:\n",
+    "        for inputs, labels in progress_bar(train_loader, parent=mb):\n",
     "            dt = datetime.datetime.now().isoformat()\n",
     "            inputs, labels = inputs.to(device), labels.to(device)\n",
     "\n",
@@ -204,7 +281,7 @@
     "            outputs = model(inputs)\n",
     "\n",
     "            # Format results\n",
-    "            _, preds = torch.max(outputs, 1)\n",
+    "            pred_idx, preds = torch.max(outputs, 1)\n",
     "            perct = [torch.nn.functional.softmax(el, dim=0)[i].item() for i, el in zip(preds, outputs)]\n",
     "            \n",
     "            loss = criterion(outputs, labels)\n",
@@ -213,17 +290,38 @@
     "            # zero the parameter gradients\n",
     "            optimizer.zero_grad()\n",
     "            loss.backward()\n",
-    "            optimizer.step()\n",
+    "            scheduler.step()\n",
+    "            \n",
+    "            # ✍️ Log your metrics to wandb ✍️\n",
+    "            logs = {\n",
+    "                    'train/train_loss': loss.item(),\n",
+    "                    'train/learning_rate':scheduler.get_last_lr()[0], \n",
+    "                    'train/correct':correct, \n",
+    "                    'train/epoch': epoch + count/len(train_loader), \n",
+    "                    'train/count': count,     \n",
+    "                }\n",
+    "            \n",
+    "            # ✍️  Occasionally some images to ensure the image data looks correct ✍️\n",
+    "            if count % 25 == 0:\n",
+    "                logs['examples/example_images'] = wandb.Image(inputs[:5], caption=f'Step: {count}')\n",
+    "            \n",
+    "            # ✍️ Log some predictions to wandb during final epoch for analysis✍️ \n",
+    "            if epoch == max(range(n_epochs)) and count % 4 == 0:\n",
+    "                for i in range(len(labels)):\n",
+    "                    preds_table.add_data(wandb.Image(inputs[i]), labels[i], preds[i], perct[i]) \n",
+    "            \n",
+    "            # ✍️  Log metrics to wandb ✍️         \n",
+    "            wandb.log(logs)\n",
+    "            \n",
     "            count += 1\n",
-    "                \n",
-    "            # Record the results of this model iteration for later review.\n",
-    "            wandb.log({\n",
-    "                    'loss': loss.item(),\n",
-    "                    'learning_rate':base_lr, \n",
-    "                    'correct':correct, \n",
-    "                    'epoch': epoch, \n",
-    "                    'count': count\n",
-    "                })"
+    "    \n",
+    "    # ✍️  Upload your predictions table for analysis ✍️  \n",
+    "    predictions_artifact = wandb.Artifact(\"train_predictions_\" + str(wandb.run.id), type=\"train_predictions\")\n",
+    "    predictions_artifact.add(preds_table, \"train_predictions\")\n",
+    "    wandb.run.log_artifact(predictions_artifact)  \n",
+    "    \n",
+    "    # ✍️ Close your wandb run ✍️ \n",
+    "    wandb.run.finish()"
    ]
   },
   {
@@ -236,19 +334,180 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 7,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2021-04-21T20:39:00.597495Z",
+     "iopub.status.busy": "2021-04-21T20:39:00.597267Z",
+     "iopub.status.idle": "2021-04-21T20:48:19.997930Z",
+     "shell.execute_reply": "2021-04-21T20:48:19.997221Z",
+     "shell.execute_reply.started": "2021-04-21T20:39:00.597469Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "                Tracking run with wandb version 0.10.27<br/>\n",
+       "                Syncing run <strong style=\"color:#cdcd00\">soft-star-11</strong> to <a href=\"https://wandb.ai\" target=\"_blank\">Weights & Biases</a> <a href=\"https://docs.wandb.com/integrations/jupyter.html\" target=\"_blank\">(Documentation)</a>.<br/>\n",
+       "                Project page: <a href=\"https://wandb.ai/morg/wandb_saturn_demo\" target=\"_blank\">https://wandb.ai/morg/wandb_saturn_demo</a><br/>\n",
+       "                Run page: <a href=\"https://wandb.ai/morg/wandb_saturn_demo/runs/25n81qv4\" target=\"_blank\">https://wandb.ai/morg/wandb_saturn_demo/runs/25n81qv4</a><br/>\n",
+       "                Run data is saved locally in <code>/home/jovyan/project/weights-and-biases/wandb/run-20210421_203907-25n81qv4</code><br/><br/>\n",
+       "            "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/srv/conda/envs/saturn/lib/python3.7/site-packages/torch/utils/data/dataloader.py:477: UserWarning: This DataLoader will create 40 worker processes in total. Our suggested max number of worker in current system is 4, which is smaller than what this DataLoader is going to create. Please be aware that excessive worker creation might get DataLoader running slow or even freeze, lower the worker number to avoid potential slowness/freeze if necessary.\n",
+      "  cpuset_checked))\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/srv/conda/envs/saturn/lib/python3.7/site-packages/torch/nn/modules/module.py:795: UserWarning: Using a non-full backward hook when the forward contains multiple autograd Nodes is deprecated and will be removed in future versions. This hook will be missing some grad_input. Please use register_full_backward_hook to get the documented behavior.\n",
+      "  warnings.warn(\"Using a non-full backward hook when the forward contains multiple autograd Nodes \"\n",
+      "/srv/conda/envs/saturn/lib/python3.7/site-packages/torch/optim/lr_scheduler.py:134: UserWarning: Detected call of `lr_scheduler.step()` before `optimizer.step()`. In PyTorch 1.1.0 and later, you should call them in the opposite order: `optimizer.step()` before `lr_scheduler.step()`.  Failure to do this will result in PyTorch skipping the first value of the learning rate schedule. See more details at https://pytorch.org/docs/stable/optim.html#how-to-adjust-learning-rate\n",
+      "  \"https://pytorch.org/docs/stable/optim.html#how-to-adjust-learning-rate\", UserWarning)\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<br/>Waiting for W&B process to finish, PID 17332<br/>Program ended successfully."
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(Label(value=' 253.28MB of 253.28MB uploaded (0.00MB deduped)\\r'), FloatProgress(value=1.0, max=…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "Find user logs for this run at: <code>/home/jovyan/project/weights-and-biases/wandb/run-20210421_203907-25n81qv4/logs/debug.log</code>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "Find internal logs for this run at: <code>/home/jovyan/project/weights-and-biases/wandb/run-20210421_203907-25n81qv4/logs/debug-internal.log</code>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<h3>Run summary:</h3><br/><style>\n",
+       "    table.wandb td:nth-child(1) { padding: 0 10px; text-align: right }\n",
+       "    </style><table class=\"wandb\">\n",
+       "<tr><td>train/train_loss</td><td>1.17772</td></tr><tr><td>train/learning_rate</td><td>0.0</td></tr><tr><td>train/correct</td><td>37</td></tr><tr><td>train/epoch</td><td>1.99379</td></tr><tr><td>train/count</td><td>160</td></tr><tr><td>_runtime</td><td>491</td></tr><tr><td>_timestamp</td><td>1619038038</td></tr><tr><td>_step</td><td>321</td></tr></table>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<h3>Run history:</h3><br/><style>\n",
+       "    table.wandb td:nth-child(1) { padding: 0 10px; text-align: right }\n",
+       "    </style><table class=\"wandb\">\n",
+       "<tr><td>train/train_loss</td><td>▄▃▅▃▆▆▅▄▄▃▃▃▃▅▅▃▄▅▂▂▃▅▅▂█▂▄▃▃▂▂▂▆▅▃▁▂▂▄▃</td></tr><tr><td>train/learning_rate</td><td>▁▂▂▃▃▄▅▆▇▇███████▇▇▇▇▆▆▅▅▅▄▄▄▃▃▂▂▂▂▁▁▁▁▁</td></tr><tr><td>train/correct</td><td>▄▆▃▅▄▅▄▅▄▆▆▆▅▄▅▆▄▃▄█▅▃▃▇▁▇▆▃▆▇▇▇▂▅▇▇▆▇▅▆</td></tr><tr><td>train/epoch</td><td>▁▁▁▂▂▂▂▂▂▃▃▃▃▃▃▄▄▄▄▄▅▅▅▅▅▅▆▆▆▆▆▆▇▇▇▇▇███</td></tr><tr><td>train/count</td><td>▁▁▂▂▂▃▃▄▄▄▅▅▅▆▆▆▇▇██▁▁▂▂▂▃▃▄▄▄▅▅▅▆▆▆▇▇▇█</td></tr><tr><td>_runtime</td><td>▁▁▁▁▂▂▂▂▂▂▃▃▃▃▃▃▃▃▃▄▅▅▅▅▆▆▆▆▆▆▇▇▇▇▇▇▇███</td></tr><tr><td>_timestamp</td><td>▁▁▁▁▂▂▂▂▂▂▃▃▃▃▃▃▃▃▃▄▅▅▅▅▆▆▆▆▆▆▇▇▇▇▇▇▇███</td></tr><tr><td>_step</td><td>▁▁▁▂▂▂▂▂▂▃▃▃▃▃▃▄▄▄▄▄▅▅▅▅▅▅▆▆▆▆▆▆▇▇▇▇▇███</td></tr></table><br/>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "Synced 7 W&B file(s), 15 media file(s), 2447 artifact file(s) and 1 other file(s)"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "                    <br/>Synced <strong style=\"color:#cdcd00\">soft-star-11</strong>: <a href=\"https://wandb.ai/morg/wandb_saturn_demo/runs/25n81qv4\" target=\"_blank\">https://wandb.ai/morg/wandb_saturn_demo/runs/25n81qv4</a><br/>\n",
+       "                "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "simple_train_single(**model_params)"
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "At this point, you can view the Weights and Biases dashboard to see the performance of the model and system resources utilization in real time!"
-   ],
-   "cell_type": "markdown",
-   "metadata": {}
+   ]
   }
  ],
  "metadata": {
@@ -267,7 +526,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.9"
+   "version": "3.7.10"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Added a couple of additional wandb logging features:

- Logging 5 images and displaying them in W&B UI every so often as a sanity check that you're data looks ok, e.g. you haven't messed up your normalisation and logged all black images, and also that your transforms aren't too agressive
- Logging ~1/4 of your dataset to W&B during the last epoch along with the label, predicted label and score. With this you can explore and aggregate the correct and incorrect predictions your model is making


[
<img width="1149" alt="Screenshot 2021-04-21 at 21 53 26" src="https://user-images.githubusercontent.com/20516801/115621023-dd60f580-a2ed-11eb-9b00-a8265a2d89e6.png">
](url)

Also added:
- fastprogress progress bar
- Swaped Label Formatting and Model Specifications cells (`imagenetclasses` was being called out of order)
- Used `OneCycleLR` scheduler to show lr logging
- Added `epoch` logging
- Added `wandb.finish()` to close the run once all logging is finished

Sample wandb run [can be found here](https://wandb.ai/morg/wandb_saturn_demo/runs/25n81qv4?workspace=user-morg), the screenshot above can be found by looking in the Artifacts sidebar under the "train_predictions" Artifact -> "train_predictions" Table